### PR TITLE
Solara: remove center 'AI'; add concentric orbits and refined blue nebula

### DIFF
--- a/src/components/products/SolaraInfographic.tsx
+++ b/src/components/products/SolaraInfographic.tsx
@@ -16,6 +16,7 @@ export default function SolaraInfographic() {
     <div className="relative w-full h-full min-h-[420px] flex items-center justify-center">
       <Starfield />
       <Constellations />
+      <Nebula reduced={!!reduced} />
 
       <motion.div
         initial={reduced ? false : { scale: 0.9, opacity: 0 }}
@@ -43,9 +44,10 @@ export default function SolaraInfographic() {
               transition={{ duration: 3.5, repeat: Infinity, ease: 'easeInOut' }}
             />
           )}
-          <span className="text-2xl md:text-3xl font-bold text-white">AI</span>
         </div>
       </motion.div>
+
+      <Orbits reduced={!!reduced} />
 
       <div className="absolute inset-0 z-10">
         {features.map((feature, index) => (
@@ -85,31 +87,6 @@ function OrbitingNode({ feature, index, reduced }: { feature: { name: string; ic
         </div>
       </motion.div>
 
-      <svg
-        className="absolute inset-0 w-full h-full pointer-events-none"
-        style={{
-          left: '50%',
-          top: '50%',
-          transform: 'translate(-50%, -50%)',
-          width: '200%',
-          height: '200%',
-        }}
-        aria-hidden
-      >
-        <motion.circle
-          initial={reduced ? { opacity: 0.18 } : { pathLength: 0 }}
-          animate={reduced ? { opacity: 0.18 } : { pathLength: 1 }}
-          transition={{ duration: 1.8, delay: 0.5 + index * 0.1 }}
-          cx="50%"
-          cy="50%"
-          r={mobileRadius}
-          fill="none"
-          stroke="url(#gradient-orbit-blue)"
-          strokeWidth="1"
-          strokeDasharray="2 4"
-          opacity="0.18"
-        />
-      </svg>
 
       <style jsx>{`
         @media (min-width: 768px) {
@@ -181,6 +158,7 @@ function Starfield() {
             width: '3px',
             height: '3px',
             left: s.left,
+
             top: s.top,
             background: 'radial-gradient(circle, rgba(255,255,255,0.9), rgba(255,255,255,0) 60%)'
           }}
@@ -207,6 +185,63 @@ function Starfield() {
         />
       ))}
     </>
+  );
+}
+
+function Orbits({ reduced }: { reduced: boolean }) {
+  const radii = [80, 115, 150];
+  return (
+    <svg className="absolute inset-0 w-full h-full pointer-events-none" aria-hidden>
+      {radii.map((r, i) => (
+        <motion.circle
+          key={r}
+          cx="50%"
+          cy="50%"
+          r={r}
+          fill="none"
+          stroke="url(#gradient-orbit-blue)"
+          strokeWidth="1.2"
+          strokeDasharray="4 10"
+          opacity="0.18"
+          initial={reduced ? { opacity: 0.18 } : { strokeDashoffset: 0 }}
+          animate={reduced ? { opacity: 0.18 } : { strokeDashoffset: 56 }}
+          transition={{ duration: 14 + i * 2, repeat: reduced ? 0 : Infinity, ease: 'linear' }}
+        />
+      ))}
+    </svg>
+  );
+}
+
+function Nebula({ reduced }: { reduced: boolean }) {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center pointer-events-none" aria-hidden>
+      <motion.div
+        className="rounded-full"
+        style={{
+          width: 380,
+          height: 380,
+          background: 'radial-gradient(45% 55% at 50% 50%, rgba(79,70,229,0.18) 0%, rgba(79,70,229,0.08) 35%, rgba(79,70,229,0) 70%)',
+          filter: 'blur(8px)',
+        }}
+        initial={{ opacity: 0.5, scale: 0.96 }}
+        animate={reduced ? { opacity: 0.5, scale: 0.96 } : { opacity: [0.45, 0.6, 0.45], scale: [0.96, 1.02, 0.96] }}
+        transition={{ duration: 9, repeat: reduced ? 0 : Infinity, ease: 'easeInOut' }}
+      />
+      {!reduced && (
+        <motion.div
+          className="absolute rounded-full"
+          style={{
+            width: 460,
+            height: 300,
+            background: 'radial-gradient(50% 60% at 50% 50%, rgba(79,70,229,0.15) 0%, rgba(79,70,229,0.06) 40%, rgba(79,70,229,0) 75%)',
+            filter: 'blur(10px)',
+          }}
+          initial={{ rotate: 0, opacity: 0.35 }}
+          animate={{ rotate: 360, opacity: [0.3, 0.45, 0.3] }}
+          transition={{ duration: 60, repeat: Infinity, ease: 'linear' }}
+        />
+      )}
+    </div>
   );
 }
 


### PR DESCRIPTION
# Solara: remove center 'AI'; add concentric orbits and refined blue nebula

## Summary
Based on user feedback showing visual issues with the Solara animation, this PR addresses two main requests:
1. **Removes the "AI" text** from the center of the Solara star animation
2. **Redesigns the orbits and nebula** to create a more natural, 3D appearance with concentric orbital rings and a layered blue nebula background

### Key Changes:
- **Central star**: Removed the "AI" label span element, keeping only the clean pulsing star
- **Orbits system**: Replaced individual per-node orbit arcs with a centralized `Orbits` component featuring three concentric, dashed rings with continuous rotation animation
- **Nebula layer**: Added new `Nebula` component with layered radial gradients creating a soft blue hazy background with subtle breathing and rotation effects
- **Render ordering**: Restructured component layering for proper visual depth (Starfield → Constellations → Nebula → Star → Orbits → Nodes → Beams)
- **Accessibility**: All new animations respect `prefers-reduced-motion` with static fallbacks

## Review & Testing Checklist for Human
- [ ] **Visual verification**: Navigate to `/products` page and confirm Solara animation looks like a proper 3D star with blue nebula and concentric orbits (most critical)
- [ ] **No "AI" text**: Verify the central star has no text label inside it
- [ ] **Animation performance**: Check that animations are smooth and don't cause performance issues, especially on mobile
- [ ] **Reduced motion compliance**: Toggle `prefers-reduced-motion` in browser dev tools and verify animations become static
- [ ] **Mobile responsiveness**: Test on mobile devices to ensure orbit radii and nebula scaling look appropriate

### Recommended Test Plan:
1. Open `/products` page in browser
2. Scroll down to Solara section
3. Observe the animation for 10-15 seconds to see full motion cycle
4. Test on mobile viewport
5. Enable reduced motion in accessibility settings and reload

---

### Diagram
```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    ProductsPage["src/app/products/page.tsx"]:::context
    SolaraComponent["SolaraInfographic.tsx"]:::major-edit
    
    ProductsPage -->|renders| SolaraComponent
    
    subgraph SolaraStructure ["Solara Component Structure"]
        Starfield["Starfield()"]:::context
        Constellations["Constellations()"]:::context
        Nebula["Nebula() - NEW"]:::major-edit
        CentralStar["Central Star<br/>(removed AI text)"]:::major-edit
        Orbits["Orbits() - NEW"]:::major-edit
        OrbitingNodes["OrbitingNode list"]:::context
        Beams["Beams()"]:::context
    end
    
    SolaraComponent --> Starfield
    SolaraComponent --> Constellations
    SolaraComponent --> Nebula
    SolaraComponent --> CentralStar
    SolaraComponent --> Orbits
    SolaraComponent --> OrbitingNodes
    SolaraComponent --> Beams
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes
- The orbit radii are currently hardcoded as `[80, 115, 150]` pixels - may need adjustment based on visual feedback
- Nebula opacity values are tuned for dark backgrounds but may need tweaking for different themes
- All new animations use consistent brand-blue colors from existing gradient definitions
- Performance impact should be minimal as animations use CSS transforms and opacity changes

**Session**: https://app.devin.ai/sessions/044ea150d3fa4822ba982c3458b9ab35  
**Requested by**: Jitin Nair (@notjitin-1994)