### PR TITLE
Anonymous tracking: identify + pageview via Prisma (Neon) and Next.js API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/app/api/track/event/route.ts
+++ b/src/app/api/track/event/route.ts
@@ -1,3 +1,6 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { randomUUID } from 'crypto';
@@ -5,6 +8,10 @@ import prisma from '../../../../lib/prisma';
 
 const COOKIE_NAME = 'anon_id';
 const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
 
 export async function POST(req: NextRequest) {
   const cookieStore = cookies() as any;

--- a/src/app/api/track/event/route.ts
+++ b/src/app/api/track/event/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { randomUUID } from 'crypto';
+import prisma from '../../../../lib/prisma';
+
+const COOKIE_NAME = 'anon_id';
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export async function POST(req: NextRequest) {
+  const cookieStore = cookies() as any;
+  let anonId = cookieStore.get(COOKIE_NAME)?.value as string | undefined;
+
+  const body = await req.json().catch(() => ({} as any));
+  const type = body?.type as string | undefined;
+  const data = body?.data as any;
+
+  if (!anonId) {
+    anonId = randomUUID();
+    await prisma.anonymousUserActivity.upsert({
+      where: { anonymousId: anonId },
+      create: {
+        id: randomUUID(),
+        anonymousId: anonId,
+        pageViews: [],
+        interactions: [],
+        courseViews: [],
+        updatedAt: new Date(),
+      },
+      update: { updatedAt: new Date() },
+    });
+  }
+
+  const record = await prisma.anonymousUserActivity.findUnique({
+    where: { anonymousId: anonId },
+    select: { pageViews: true, interactions: true },
+  });
+
+  const nowIso = new Date().toISOString();
+
+  if (type === 'pageview') {
+    const pageViews = Array.isArray(record?.pageViews) ? (record?.pageViews as any[]) : [];
+    pageViews.push({ ...data, ts: nowIso });
+
+    await prisma.anonymousUserActivity.update({
+      where: { anonymousId: anonId },
+      data: {
+        pageViews,
+        updatedAt: new Date(),
+      },
+    });
+  } else if (type === 'interaction') {
+    const interactions = Array.isArray(record?.interactions) ? (record?.interactions as any[]) : [];
+    interactions.push({ ...data, ts: nowIso });
+
+    await prisma.anonymousUserActivity.update({
+      where: { anonymousId: anonId },
+      data: {
+        interactions,
+        updatedAt: new Date(),
+      },
+    });
+  } else {
+    return NextResponse.json({ ok: false, error: 'Invalid type' }, { status: 400 });
+  }
+
+  const res = NextResponse.json({ ok: true, anonymousId: anonId });
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value: anonId,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: ONE_YEAR,
+  });
+
+  return res;
+}

--- a/src/app/api/track/identify/route.ts
+++ b/src/app/api/track/identify/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { randomUUID } from 'crypto';
+import prisma from '../../../../lib/prisma';
+
+const COOKIE_NAME = 'anon_id';
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export async function POST() {
+  const cookieStore = cookies() as any;
+  let anonId = cookieStore.get(COOKIE_NAME)?.value as string | undefined;
+
+  if (!anonId) {
+    anonId = randomUUID();
+  }
+
+  await prisma.anonymousUserActivity.upsert({
+    where: { anonymousId: anonId },
+    create: {
+      id: randomUUID(),
+      anonymousId: anonId,
+      pageViews: [],
+      interactions: [],
+      courseViews: [],
+      updatedAt: new Date(),
+    },
+    update: {
+      updatedAt: new Date(),
+    },
+  });
+
+  const res = NextResponse.json({ ok: true, anonymousId: anonId });
+  res.cookies.set({
+    name: COOKIE_NAME,
+    value: anonId,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: ONE_YEAR,
+  });
+
+  return res;
+}

--- a/src/app/api/track/identify/route.ts
+++ b/src/app/api/track/identify/route.ts
@@ -1,3 +1,6 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { randomUUID } from 'crypto';
@@ -5,6 +8,10 @@ import prisma from '../../../../lib/prisma';
 
 const COOKIE_NAME = 'anon_id';
 const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export async function GET() {
+  return NextResponse.json({ ok: true });
+}
 
 export async function POST() {
   const cookieStore = cookies() as any;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import Header from "@/components/layout/Header";
 import Footer from "@/components/layout/Footer";
 import GetStartedModal from "@/components/auth/GetStartedModal";
+import TrackClient from "@/components/providers/TrackClient";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -62,6 +63,7 @@ export default function RootLayout({
             </main>
             <Footer />
             <GetStartedModal />
+            <TrackClient />
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,8 @@ import Footer from "@/components/layout/Footer";
 import GetStartedModal from "@/components/auth/GetStartedModal";
 import TrackClient from "@/components/providers/TrackClient";
 import "./globals.css";
+import { Suspense } from "react";
+
 
 export const metadata: Metadata = {
   title: "SmartSlate - Build Your Future-Ready Workforce",
@@ -63,7 +65,9 @@ export default function RootLayout({
             </main>
             <Footer />
             <GetStartedModal />
-            <TrackClient />
+            <Suspense fallback={null}>
+              <TrackClient />
+            </Suspense>
           </AuthProvider>
         </ThemeProvider>
       </body>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: 'SmartSlate',
+    short_name: 'SmartSlate',
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#091521',
+    theme_color: '#091521',
+    icons: [
+      { src: '/logo-swirl.png', sizes: '192x192', type: 'image/png' },
+      { src: '/logo-swirl.png', sizes: '512x512', type: 'image/png' }
+    ],
+  };
+}

--- a/src/components/providers/TrackClient.tsx
+++ b/src/components/providers/TrackClient.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+function parseUtm(search: string) {
+  const params = new URLSearchParams(search);
+  const keys = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
+  const out: Record<string, string> = {};
+  for (const k of keys) {
+    const v = params.get(k);
+    if (v) out[k] = v;
+  }
+  return out;
+}
+
+async function postJSON(url: string, body: any) {
+  try {
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+  } catch {}
+}
+
+export default function TrackClient() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    postJSON('/api/track/identify', {});
+  }, []);
+
+  useEffect(() => {
+    const search = searchParams?.toString() || '';
+    const payload = {
+      pathname,
+      search,
+      referrer: typeof document !== 'undefined' ? document.referrer : '',
+      utm: parseUtm(search),
+      viewport: {
+        w: typeof window !== 'undefined' ? window.innerWidth : null,
+        h: typeof window !== 'undefined' ? window.innerHeight : null,
+      },
+      userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    };
+    postJSON('/api/track/event', { type: 'pageview', data: payload });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['warn', 'error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../generated/prisma';
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
 


### PR DESCRIPTION
# Anonymous tracking: identify + pageview via Prisma (Neon) and Next.js API

## Summary

Implements anonymous user tracking for the SmartSlate Next.js application using the existing Prisma + Neon PostgreSQL infrastructure. This tracks all visitors with persistent anonymous identifiers and captures pageview data, setting the foundation for future authentication-based data merging.

**Key Changes:**
- Added API routes `/api/track/identify` and `/api/track/event` for anonymous user tracking
- Created `TrackClient` component that automatically tracks pageviews on route changes  
- Integrated tracking into the root layout to capture all navigation
- Uses HTTP-only cookies for persistent anonymous IDs (365-day retention)
- Stores data in existing `AnonymousUserActivity` table via Prisma ORM

## Review & Testing Checklist for Human

- [ ] **Test API endpoints manually** - Verify `/api/track/identify` and `/api/track/event` return 200 responses and set cookies correctly (I couldn't test due to DATABASE_URL env issue)
- [ ] **Verify database writes** - Check that `AnonymousUserActivity` records are actually created/updated in Neon database with pageview JSON data
- [ ] **Test cross-page navigation** - Navigate between pages (/, /products, /courses, /difference) and confirm tracking fires without errors in browser DevTools Network tab
- [ ] **Check cookie persistence** - Verify `anon_id` cookie persists across browser sessions and API calls include it correctly
- [ ] **Performance testing** - Ensure tracking doesn't cause noticeable performance issues or excessive API calls during normal browsing

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    Browser["Browser<br/>(user navigation)"]
    Layout["src/app/layout.tsx<br/>(RootLayout)"]:::minor-edit
    TrackClient["src/components/providers/<br/>TrackClient.tsx"]:::major-edit
    IdentifyAPI["src/app/api/track/<br/>identify/route.ts"]:::major-edit
    EventAPI["src/app/api/track/<br/>event/route.ts"]:::major-edit
    PrismaClient["src/lib/prisma.ts"]:::major-edit
    Database["Neon PostgreSQL<br/>(AnonymousUserActivity)"]:::context

    Browser -->|"pageview on route change"| TrackClient
    Layout -->|"mounts"| TrackClient
    TrackClient -->|"POST /api/track/identify"| IdentifyAPI
    TrackClient -->|"POST /api/track/event"| EventAPI
    IdentifyAPI -->|"upsert record"| PrismaClient
    EventAPI -->|"update pageViews JSON"| PrismaClient
    PrismaClient -->|"SQL queries"| Database

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

**Environment Issue:** Prisma migration failed during development due to DATABASE_URL format validation, so end-to-end testing was not possible. The code changes are complete but require database connectivity verification.

**Implementation Details:**
- Anonymous IDs are UUIDs stored in HTTP-only cookies for security
- Pageview data includes pathname, UTM parameters, viewport size, referrer, and timestamp
- JSON array updates use read-modify-write pattern (potential concurrency edge case)
- Used type casting workaround for Next.js cookies API compatibility

**Future Considerations:** When authentication is implemented, this tracking data can be merged with authenticated user profiles using the `anonymousId` field.

---
**Link to Devin run:** https://app.devin.ai/sessions/c120b865bdc74e35ad332e9ed3dd8551  
**Requested by:** Jitin Nair (@notjitin-1994)