### PR TITLE
fix: resolve authentication loop by using correct Stack Auth token API

### DIFF
--- a/src/components/providers/StackProvider.tsx
+++ b/src/components/providers/StackProvider.tsx
@@ -65,33 +65,28 @@ function StackAuthSyncInner({ children }: { children: React.ReactNode }) {
       syncUserToDatabase();
 
       // Obtain a real token from Stack (if available) and sync AuthContext
-      const getIdToken = async (): Promise<string | null> => {
+      const getAccessToken = async (): Promise<string | null> => {
         try {
-          console.log('🔑 Attempting to get Stack ID token...');
-          const su = stackUser as unknown as { getIdToken?: () => Promise<string> };
-          if (typeof su?.getIdToken === 'function') {
-            const token = await su.getIdToken();
-            console.log('✅ Stack ID token acquired:', token ? 'Token received' : 'Token is null/empty');
-            return typeof token === 'string' ? token : null;
-          } else {
-            console.warn('⚠️ getIdToken method not available on Stack user object');
-          }
+          console.log('🔑 Attempting to get Stack access token...');
+          const authData = await stackUser.getAuthJson();
+          console.log('✅ Stack auth data acquired:', authData.accessToken ? 'Access token received' : 'No access token');
+          return authData.accessToken;
         } catch (e) {
-          console.error('❌ Failed to get Stack ID token:', e);
+          console.error('❌ Failed to get Stack access token:', e);
         }
         return null;
       };
 
-      getIdToken().then((idToken) => {
-        if (idToken) {
-          console.log('🎯 Logging in to AuthContext with Stack token');
-          login(idToken, {
+      getAccessToken().then((accessToken) => {
+        if (accessToken) {
+          console.log('🎯 Logging in to AuthContext with Stack access token');
+          login(accessToken, {
             id: Date.now(),
             full_name: stackUser.displayName || stackUser.primaryEmail?.split('@')[0] || 'User',
             email: stackUser.primaryEmail || '',
           });
         } else {
-          console.warn('⚠️ No Stack ID token available; skipping local AuthContext login');
+          console.warn('⚠️ No Stack access token available; skipping local AuthContext login');
         }
       });
     } else if (!stackUser && user) {


### PR DESCRIPTION
# fix: resolve authentication loop by using correct Stack Auth token API

## Summary

Fixes the frontend authentication loop where users got stuck between `/profile` and `/handler/sign-in` pages after successful backend authentication. The root cause was attempting to use a non-existent `getIdToken()` method on Stack Auth user objects, which prevented proper token acquisition and sync with local `AuthContext`.

**Key Changes:**
- Replaced `getIdToken()` method with correct `getAuthJson()` method in `StackProvider.tsx`
- Updated token acquisition to use `accessToken` from Stack Auth response
- Maintained existing logging patterns for consistency with PR #14

**Impact:**
- Resolves authentication state mismatch between Stack Auth and local `AuthContext`
- Eliminates redirect loops for authenticated users
- Enables proper access to protected pages like `/profile`

## Review & Testing Checklist for Human

- [ ] **Test complete signup flow** with a new user email to verify token acquisition works end-to-end
- [ ] **Verify backend token validation** - confirm the `accessToken` from Stack Auth is properly validated by existing JWT middleware 
- [ ] **Test on Vercel preview deployment** - local testing showed success but production environment may behave differently
- [ ] **Navigate between protected/unprotected pages** to ensure no new redirect loops or authentication issues
- [ ] **Check browser refresh behavior** - verify authentication state persists across page reloads

**Recommended Test Plan:**
1. Deploy to Vercel preview and test signup flow with fresh email
2. Sign out and sign back in to test existing user flow  
3. Navigate directly to `/profile` and other protected routes
4. Refresh browser on protected pages to test session persistence

## Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    User[User Authentication Flow]
    StackAuth["@stackframe/stack<br/>Stack Auth Library"]
    StackProvider["src/components/providers/<br/>StackProvider.tsx"]:::major-edit
    AuthContext["src/contexts/<br/>AuthContext.tsx"]:::context
    ProfilePage["src/app/profile/<br/>page.tsx"]:::context
    SignInHandler["src/app/handler/<br/>sign-in"]:::context

    User --> StackAuth
    StackAuth --> StackProvider
    StackProvider --> AuthContext
    AuthContext --> ProfilePage
    ProfilePage -.-> SignInHandler

    StackProvider --> |"getAuthJson().accessToken"| AuthContext
    StackProvider -.-> |"Fixed: was using<br/>non-existent getIdToken()"| StackAuth

    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

## Notes

**Link to Devin run:** https://app.devin.ai/sessions/1de027cb6ded4ace8ef77a56eef5687f

**Requested by:** @notjitin-1994

**Testing performed:** Local testing confirmed authentication loop is resolved and profile page loads correctly. However, there were still 500 errors on `/api/auth/verify-user` endpoint during testing, which appear to be separate backend issues not related to this token acquisition fix.

**Risk assessment:** Medium - while the code change is minimal and targeted, authentication is critical functionality and the new `accessToken` format needs verification against existing backend JWT validation logic.